### PR TITLE
Adjust list report display behavior

### DIFF
--- a/webapp/css/style.css
+++ b/webapp/css/style.css
@@ -1,0 +1,17 @@
+/* Custom styles for the list report table */
+div[id^="application-kassenbelegansicht"] .sapMListTblCell a {
+  pointer-events: none;
+  color: inherit;
+  text-decoration: none;
+  cursor: default;
+}
+
+div[id^="application-kassenbelegansicht"] .sapMListTblCell,
+div[id^="application-kassenbelegansicht"] .sapMListTblRow {
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+}
+
+div[id^="application-kassenbelegansicht"] .sapMListTblCell .sapMText {
+  line-height: 1.2;
+}

--- a/webapp/ext/controller/ListReportExt.controller.js
+++ b/webapp/ext/controller/ListReportExt.controller.js
@@ -1,0 +1,10 @@
+sap.ui.define([], function () {
+  "use strict";
+
+  return {
+    onListNavigationExtension: function () {
+      // Returning false prevents navigation to the object page when a row is pressed.
+      return false;
+    }
+  };
+});

--- a/webapp/manifest.json
+++ b/webapp/manifest.json
@@ -108,7 +108,20 @@
       }
     },
     "resources": {
-      "css": []
+      "css": [
+        {
+          "uri": "css/style.css"
+        }
+      ]
+    },
+    "extends": {
+      "extensions": {
+        "sap.ui.controllerExtensions": {
+          "sap.suite.ui.generic.template.ListReport.view.ListReport": {
+            "controllerName": "kassenbeleg.ansicht.kassenbelegansicht.ext.controller.ListReportExt"
+          }
+        }
+      }
     },
     "routing": {
       "config": {},
@@ -131,6 +144,7 @@
           "name": "sap.suite.ui.generic.template.ListReport",
           "list": true,
           "settings": {
+            "initialLoad": true,
             "condensedTableLayout": true,
             "smartVariantManagement": true,
             "enableTableFilterInPageVariant": true,


### PR DESCRIPTION
## Summary
- load the list report automatically on startup and register a controller extension to stop object page navigation
- add styling to render list entries as plain text and tighten the responsive table row spacing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e61b9948348324bbfb85c9b081dd75