### PR TITLE
Disable list navigation and auto load list data

### DIFF
--- a/webapp/css/style.css
+++ b/webapp/css/style.css
@@ -1,0 +1,16 @@
+.appListCompact .sapMListTblCell {
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+}
+
+.appListCompact .sapMListTblRow {
+  height: auto;
+}
+
+.appListCompact .sapMListTblRow .sapMText {
+  line-height: 1.2rem;
+}
+
+.appListCompact .sapMListTblCell:first-child {
+  padding-left: 0.5rem;
+}

--- a/webapp/css/style.css
+++ b/webapp/css/style.css
@@ -14,3 +14,17 @@
 .appListCompact .sapMListTblCell:first-child {
   padding-left: 0.5rem;
 }
+
+.appListCompact.sapUiTable .sapUiTableCell {
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+}
+
+.appListCompact.sapUiTable .sapUiTableCell > .sapMText {
+  line-height: 1.2rem;
+}
+
+.appListCompact.sapUiTable .sapUiTableRowHdr,
+.appListCompact.sapUiTable .sapUiTableCtrl tr {
+  height: auto;
+}

--- a/webapp/ext/controller/ListReportExt.controller.js
+++ b/webapp/ext/controller/ListReportExt.controller.js
@@ -1,0 +1,85 @@
+sap.ui.define([
+  "sap/ui/core/mvc/ControllerExtension",
+  "sap/m/Text"
+], function (ControllerExtension, Text) {
+  "use strict";
+
+  function convertLinksToText(oTable) {
+    if (!oTable || !oTable.isA || !oTable.isA("sap.m.Table")) {
+      return;
+    }
+
+    var oItemsBindingInfo = oTable.getBindingInfo("items");
+    if (!oItemsBindingInfo || !oItemsBindingInfo.template) {
+      return;
+    }
+
+    var oTemplate = oItemsBindingInfo.template;
+    var aCells = oTemplate.getCells();
+
+    aCells.forEach(function (oCell, iIndex) {
+      if (oCell && oCell.isA && oCell.isA("sap.m.Link")) {
+        var oText = new Text({
+          wrapping: false
+        });
+
+        var oTextBindingInfo = oCell.getBindingInfo("text");
+        if (oTextBindingInfo) {
+          oText.bindProperty("text", oTextBindingInfo);
+        } else if (typeof oCell.getText === "function") {
+          oText.setText(oCell.getText());
+        }
+
+        var oTooltipBindingInfo = oCell.getBindingInfo("tooltip");
+        if (oTooltipBindingInfo) {
+          oText.bindProperty("tooltip", oTooltipBindingInfo);
+        } else if (typeof oCell.getTooltip === "function") {
+          oText.setTooltip(oCell.getTooltip());
+        }
+
+        oTemplate.removeCell(oCell);
+        oCell.destroy();
+        oTemplate.insertCell(oText, iIndex);
+      }
+    });
+  }
+
+  function prepareTable(oTable) {
+    if (!oTable) {
+      return;
+    }
+
+    if (typeof oTable.addStyleClass === "function") {
+      oTable.addStyleClass("appListCompact");
+    }
+
+    convertLinksToText(oTable);
+  }
+
+  return ControllerExtension.extend("kassenbeleg.ansicht.kassenbelegansicht.ext.controller.ListReportExt", {
+    override: {
+      onInitSmartTableExtension: function (oEvent) {
+        var oSmartTable = oEvent && oEvent.getSource && oEvent.getSource();
+        var oTable = oSmartTable && oSmartTable.getTable && oSmartTable.getTable();
+        prepareTable(oTable);
+      },
+
+      onBeforeRebindTableExtension: function (oEvent) {
+        var oSmartTable = oEvent && oEvent.getSource && oEvent.getSource();
+        var oTable = oSmartTable && oSmartTable.getTable && oSmartTable.getTable();
+        prepareTable(oTable);
+      },
+
+      onInitSmartFilterBarExtension: function (oEvent) {
+        var oSmartFilterBar = oEvent && oEvent.getSource && oEvent.getSource();
+        if (oSmartFilterBar && typeof oSmartFilterBar.attachEventOnce === "function") {
+          oSmartFilterBar.attachEventOnce("initialise", function () {
+            if (typeof oSmartFilterBar.search === "function") {
+              oSmartFilterBar.search();
+            }
+          });
+        }
+      }
+    }
+  });
+});

--- a/webapp/ext/controller/ListReportExt.controller.js
+++ b/webapp/ext/controller/ListReportExt.controller.js
@@ -4,11 +4,29 @@ sap.ui.define([
 ], function (ControllerExtension, Text) {
   "use strict";
 
-  function convertLinksToText(oTable) {
-    if (!oTable || !oTable.isA || !oTable.isA("sap.m.Table")) {
-      return;
+  function createTextFromLink(oLink) {
+    var oText = new Text({
+      wrapping: false
+    });
+
+    var oTextBindingInfo = oLink.getBindingInfo && oLink.getBindingInfo("text");
+    if (oTextBindingInfo) {
+      oText.bindProperty("text", oTextBindingInfo);
+    } else if (typeof oLink.getText === "function") {
+      oText.setText(oLink.getText());
     }
 
+    var oTooltipBindingInfo = oLink.getBindingInfo && oLink.getBindingInfo("tooltip");
+    if (oTooltipBindingInfo) {
+      oText.bindProperty("tooltip", oTooltipBindingInfo);
+    } else if (typeof oLink.getTooltip === "function") {
+      oText.setTooltip(oLink.getTooltip());
+    }
+
+    return oText;
+  }
+
+  function convertResponsiveTableLinksToText(oTable) {
     var oItemsBindingInfo = oTable.getBindingInfo("items");
     if (!oItemsBindingInfo || !oItemsBindingInfo.template) {
       return;
@@ -19,24 +37,7 @@ sap.ui.define([
 
     aCells.forEach(function (oCell, iIndex) {
       if (oCell && oCell.isA && oCell.isA("sap.m.Link")) {
-        var oText = new Text({
-          wrapping: false
-        });
-
-        var oTextBindingInfo = oCell.getBindingInfo("text");
-        if (oTextBindingInfo) {
-          oText.bindProperty("text", oTextBindingInfo);
-        } else if (typeof oCell.getText === "function") {
-          oText.setText(oCell.getText());
-        }
-
-        var oTooltipBindingInfo = oCell.getBindingInfo("tooltip");
-        if (oTooltipBindingInfo) {
-          oText.bindProperty("tooltip", oTooltipBindingInfo);
-        } else if (typeof oCell.getTooltip === "function") {
-          oText.setTooltip(oCell.getTooltip());
-        }
-
+        var oText = createTextFromLink(oCell);
         oTemplate.removeCell(oCell);
         oCell.destroy();
         oTemplate.insertCell(oText, iIndex);
@@ -44,21 +45,45 @@ sap.ui.define([
     });
   }
 
+  function convertGridTableLinksToText(oTable) {
+    var aColumns = oTable.getColumns();
+
+    aColumns.forEach(function (oColumn) {
+      var oTemplate = oColumn && oColumn.getTemplate && oColumn.getTemplate();
+      if (oTemplate && oTemplate.isA && oTemplate.isA("sap.m.Link")) {
+        var oText = createTextFromLink(oTemplate);
+        oColumn.setTemplate(oText);
+      }
+    });
+  }
+
   function prepareTable(oTable) {
-    if (!oTable) {
+    if (!oTable || typeof oTable.addStyleClass !== "function" || !oTable.isA) {
       return;
     }
 
-    if (typeof oTable.addStyleClass === "function") {
-      oTable.addStyleClass("appListCompact");
+    oTable.addStyleClass("appListCompact");
+
+    if (oTable.isA("sap.m.Table")) {
+      convertResponsiveTableLinksToText(oTable);
+    } else if (oTable.isA("sap.ui.table.Table")) {
+      convertGridTableLinksToText(oTable);
     }
 
-    convertLinksToText(oTable);
+    if (typeof oTable.invalidate === "function") {
+      oTable.invalidate();
+    }
   }
 
   return ControllerExtension.extend("kassenbeleg.ansicht.kassenbelegansicht.ext.controller.ListReportExt", {
     override: {
       onInitSmartTableExtension: function (oEvent) {
+        var oSmartTable = oEvent && oEvent.getSource && oEvent.getSource();
+        var oTable = oSmartTable && oSmartTable.getTable && oSmartTable.getTable();
+        prepareTable(oTable);
+      },
+
+      onAfterRenderingSmartTableExtension: function (oEvent) {
         var oSmartTable = oEvent && oEvent.getSource && oEvent.getSource();
         var oTable = oSmartTable && oSmartTable.getTable && oSmartTable.getTable();
         prepareTable(oTable);
@@ -71,13 +96,26 @@ sap.ui.define([
       },
 
       onInitSmartFilterBarExtension: function (oEvent) {
+        var that = this;
         var oSmartFilterBar = oEvent && oEvent.getSource && oEvent.getSource();
+        if (this.base && typeof this.base.onInitSmartFilterBarExtension === "function") {
+          this.base.onInitSmartFilterBarExtension.apply(this, arguments);
+        }
+
         if (oSmartFilterBar && typeof oSmartFilterBar.attachEventOnce === "function") {
-          oSmartFilterBar.attachEventOnce("initialise", function () {
+          var fnTriggerSearch = function () {
             if (typeof oSmartFilterBar.search === "function") {
               oSmartFilterBar.search();
+            } else if (that.base && that.base.getExtensionAPI && typeof that.base.getExtensionAPI === "function") {
+              var oExtensionAPI = that.base.getExtensionAPI();
+              if (oExtensionAPI && typeof oExtensionAPI.refreshTable === "function") {
+                oExtensionAPI.refreshTable(true);
+              }
             }
-          });
+          };
+
+          oSmartFilterBar.attachEventOnce("initialise", fnTriggerSearch);
+          oSmartFilterBar.attachEventOnce("afterVariantInitialise", fnTriggerSearch);
         }
       }
     }

--- a/webapp/manifest.json
+++ b/webapp/manifest.json
@@ -108,7 +108,20 @@
       }
     },
     "resources": {
-      "css": []
+      "css": [
+        {
+          "uri": "css/style.css"
+        }
+      ]
+    },
+    "extends": {
+      "extensions": {
+        "sap.ui.controllerExtensions": {
+          "sap.suite.ui.generic.template.ListReport.view.ListReport": {
+            "controllerName": "kassenbeleg.ansicht.kassenbelegansicht.ext.controller.ListReportExt"
+          }
+        }
+      }
     },
     "routing": {
       "config": {},


### PR DESCRIPTION
## Summary
- convert List Report link cells into plain text via controller extension and apply a compact table style
- add custom CSS to shrink row spacing for the responsive table
- trigger the Smart Filter Bar search on initialization to show data immediately

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e632e7fc708324b80d587e7d55129f